### PR TITLE
Added "MagentoRouter" component + tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,7 @@
     "development": {
       "plugins": [
         "transform-object-rest-spread",
+        "transform-class-properties",
         ["transform-react-jsx", { "pragma": "createElement" }]
       ]
     },
@@ -10,6 +11,7 @@
       "plugins": [
         "transform-es2015-modules-commonjs",
         "transform-object-rest-spread",
+        "transform-class-properties",
         ["transform-react-jsx", { "pragma": "createElement" }]
       ]
     }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,7 @@ const config = {
         es6: true,
         node: true
     },
+    parser: 'babel-eslint',
     parserOptions: {
         ecmaFeatures: {
             experimentalObjectRestSpread: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,116 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.31.tgz",
+      "integrity": "sha512-yd7CkUughvHQoEahQqcMdrZw6o/6PwUxiRkfZuVDVHCDe77mysD/suoNyk5mK6phTnRW1kyIbPHyCJgxw++LXg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.31.tgz",
+      "integrity": "sha512-c+DAyp8LMm2nzSs2uXEuxp4LYGSUYEyHtU3fU57avFChjsnTmmpWmXj2dv0yUxHTEydgVAv5fIzA+4KJwoqWDA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "7.0.0-beta.31",
+        "@babel/template": "7.0.0-beta.31",
+        "@babel/traverse": "7.0.0-beta.31",
+        "@babel/types": "7.0.0-beta.31"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.31.tgz",
+      "integrity": "sha512-m7rVVX/dMLbbB9NCzKYRrrFb0qZxgpmQ4Wv6y7zEsB6skoJHRuXVeb/hAFze79vXBbuD63ci7AVHXzAdZSk9KQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.31"
+      }
+    },
+    "@babel/template": {
+      "version": "7.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.31.tgz",
+      "integrity": "sha512-97IRmLvoDhIDSQkqklVt3UCxJsv0LUEVb/0DzXWtc8Lgiyxj567qZkmTG9aR21CmcJVVIvq2Y/moZj4oEpl5AA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.31",
+        "@babel/types": "7.0.0-beta.31",
+        "babylon": "7.0.0-beta.31",
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.31",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.31.tgz",
+          "integrity": "sha512-6lm2mV3S51yEnKmQQNnswoABL1U1H1KHoCCVwdwI3hvIv+W7ya4ki7Aw4o4KxtUHjNKkK5WpZb22rrMMOcJXJQ==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.31.tgz",
+      "integrity": "sha512-3N+VJW+KlezEjFBG7WSYeMyC5kIqVLPb/PGSzCDPFcJrnArluD1GIl7Y3xC7cjKiTq2/JohaLWHVPjJWHlo9Gg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.31",
+        "@babel/helper-function-name": "7.0.0-beta.31",
+        "@babel/types": "7.0.0-beta.31",
+        "babylon": "7.0.0-beta.31",
+        "debug": "3.1.0",
+        "globals": "10.4.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.31",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.31.tgz",
+          "integrity": "sha512-6lm2mV3S51yEnKmQQNnswoABL1U1H1KHoCCVwdwI3hvIv+W7ya4ki7Aw4o4KxtUHjNKkK5WpZb22rrMMOcJXJQ==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "10.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
+          "integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.31.tgz",
+      "integrity": "sha512-exAHB+NeFGxkfQ5dSUD03xl3zYGneeSk2Mw2ldTt/nTvYxuDiuSp3DlxgUBgzbdTFG4fbwPk0WtKWOoTXCmNGg==",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "2.0.0"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
+      }
+    },
     "@types/node": {
       "version": "8.0.53",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.53.tgz",
@@ -17,18 +127,18 @@
       "dev": true
     },
     "acorn": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-      "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+      "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
       "dev": true
     },
     "acorn-globals": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
-      "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+      "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13"
+        "acorn": "5.2.1"
       }
     },
     "acorn-jsx": {
@@ -387,6 +497,26 @@
         "source-map": "0.5.7"
       }
     },
+    "babel-eslint": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.0.3.tgz",
+      "integrity": "sha512-7D4iUpylEiKJPGbeSAlNddGcmA41PadgZ6UAb6JVyh003h3d0EbZusYFBR/+nBgqtaVJM2J2zUVa3N0hrpMH6g==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.31",
+        "@babel/traverse": "7.0.0-beta.31",
+        "@babel/types": "7.0.0-beta.31",
+        "babylon": "7.0.0-beta.31"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.31",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.31.tgz",
+          "integrity": "sha512-6lm2mV3S51yEnKmQQNnswoABL1U1H1KHoCCVwdwI3hvIv+W7ya4ki7Aw4o4KxtUHjNKkK5WpZb22rrMMOcJXJQ==",
+          "dev": true
+        }
+      }
+    },
     "babel-generator": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
@@ -414,6 +544,29 @@
         "esutils": "2.0.2"
       }
     },
+    "babel-helper-function-name": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+      "dev": true,
+      "requires": {
+        "babel-helper-get-function-arity": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
+    "babel-helper-get-function-arity": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
     "babel-helpers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
@@ -425,13 +578,13 @@
       }
     },
     "babel-jest": {
-      "version": "21.3.0-beta.8",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-21.3.0-beta.8.tgz",
-      "integrity": "sha512-Py2PT1/OU60lHhoKBRNC9VDN+vk+PE2dDS6Q+b4BC7R5gUdFIdJrRqfnJja3Aa+OWNozU6olrcjvYl0HpuAw1Q==",
+      "version": "21.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-21.3.0-beta.13.tgz",
+      "integrity": "sha512-iKc6vFoEQEWK/lUUv1MQ958MxpYrhYr08eDVkNckxztgt7bLuu6MdkTYxHZnwWPVhnsijDqsT0aK42EyJaIF4w==",
       "dev": true,
       "requires": {
         "babel-plugin-istanbul": "4.1.5",
-        "babel-preset-jest": "21.3.0-beta.8"
+        "babel-preset-jest": "21.3.0-beta.13"
       }
     },
     "babel-messages": {
@@ -455,9 +608,15 @@
       }
     },
     "babel-plugin-jest-hoist": {
-      "version": "21.3.0-beta.8",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.3.0-beta.8.tgz",
-      "integrity": "sha512-vdQDf8ORTk5TZ19W1BOlemo8muTEZkoackEp5StTfNjqrIkPAs88mKzToM+Bde+ZshilxefEJNuISOACVgfhyQ==",
+      "version": "21.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.3.0-beta.13.tgz",
+      "integrity": "sha512-TD7sABmWIYcq5AU6eFA4HIXOnOt6jgfTIlk3t9DXVvfB73fbSpqWtNRhkBFhXuiVoeK2jWRFjPjDJ9cAruNXCw==",
+      "dev": true
+    },
+    "babel-plugin-syntax-class-properties": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz",
+      "integrity": "sha1-1+sjt5oxf4VDlixQW4J8fWysJ94=",
       "dev": true
     },
     "babel-plugin-syntax-jsx": {
@@ -471,6 +630,18 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
+    },
+    "babel-plugin-transform-class-properties": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
+      "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
+      "dev": true,
+      "requires": {
+        "babel-helper-function-name": "6.24.1",
+        "babel-plugin-syntax-class-properties": "6.13.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.26.0",
@@ -541,12 +712,12 @@
       }
     },
     "babel-preset-jest": {
-      "version": "21.3.0-beta.8",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-21.3.0-beta.8.tgz",
-      "integrity": "sha512-txUoaEVbpo/f3KRTzN7k14sdIcXCnDskehyH3Wx3GLLlTMJIl4bTnH8A+m8YF0vDJAoFKhl+IFUkLm2xEaM39A==",
+      "version": "21.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-21.3.0-beta.13.tgz",
+      "integrity": "sha512-juHBlQ+e30Cegv+e2wDIu40+F4A4S5VFYEBohL91Y1toFNNx2lCkm5drXwlAyvjcx3NZvqL3bWO10RkaDJPDKQ==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "21.3.0-beta.8",
+        "babel-plugin-jest-hoist": "21.3.0-beta.13",
         "babel-plugin-syntax-object-rest-spread": "6.13.0"
       }
     },
@@ -662,6 +833,13 @@
       "dev": true,
       "optional": true
     },
+    "bindings": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
+      "dev": true,
+      "optional": true
+    },
     "boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -697,6 +875,12 @@
         "preserve": "0.2.0",
         "repeat-element": "1.1.2"
       }
+    },
+    "browser-process-hrtime": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
+      "integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
+      "dev": true
     },
     "browser-resolve": {
       "version": "1.11.2",
@@ -819,9 +1003,9 @@
       }
     },
     "ci-info": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.1.tgz",
-      "integrity": "sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
       "dev": true
     },
     "circular-json": {
@@ -1153,6 +1337,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
       "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "dev": true
+    },
+    "domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.0.tgz",
+      "integrity": "sha512-WpwuBlZ2lQRFa4H/4w49deb9rJLot9KmqrKKjMc9qBl7CID+DdC2swoa34ccRl+anL2B6bLp6TjFdIdnzekMBQ==",
       "dev": true
     },
     "domhandler": {
@@ -1515,16 +1705,16 @@
       }
     },
     "expect": {
-      "version": "21.3.0-beta.8",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-21.3.0-beta.8.tgz",
-      "integrity": "sha512-trvrQHbqQYIVIHw4PYGJ7MPA7Hvz2dcnpHoPeeFGldZVSEnkGGDxgBiJLWEkyhjsHpFzdJiw+63u+KzE1SxZYQ==",
+      "version": "21.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-21.3.0-beta.13.tgz",
+      "integrity": "sha512-znUtG/+/tLNTuLLf37Xc9cfyOS4ICIIilpvoWVB+LAI6C3BrnMtlmFRNosXl1ncWiJjdhIIje5XoTtYxnyA32Q==",
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
-        "jest-diff": "21.3.0-beta.8",
-        "jest-get-type": "21.3.0-beta.8",
-        "jest-matcher-utils": "21.3.0-beta.8",
-        "jest-message-util": "21.3.0-beta.8",
+        "jest-diff": "21.3.0-beta.13",
+        "jest-get-type": "21.3.0-beta.13",
+        "jest-matcher-utils": "21.3.0-beta.13",
+        "jest-message-util": "21.3.0-beta.13",
         "jest-regex-util": "21.2.0"
       }
     },
@@ -3010,7 +3200,7 @@
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
       "dev": true,
       "requires": {
-        "ci-info": "1.1.1"
+        "ci-info": "1.1.2"
       }
     },
     "is-date-object": {
@@ -3321,18 +3511,18 @@
       }
     },
     "jest": {
-      "version": "21.3.0-beta.8",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-21.3.0-beta.8.tgz",
-      "integrity": "sha512-DdZiI8I54FxJixPzGMbSAa0/5m01tO6m+R/2RKaXg1uH7J9n8BNaRWvmtSmny/tJBPwxiQo0nP1VrTugYUKQ4g==",
+      "version": "21.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-21.3.0-beta.13.tgz",
+      "integrity": "sha512-91RhU9h71D9CY0JKQwmcpcaQhiJRUGNC6q2ww9HM5/FMhf9UiQAMBlfQqskLkZX/NjxESc3pZzeBEvkB6EmNwA==",
       "dev": true,
       "requires": {
-        "jest-cli": "21.3.0-beta.8"
+        "jest-cli": "21.3.0-beta.13"
       },
       "dependencies": {
         "jest-cli": {
-          "version": "21.3.0-beta.8",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-21.3.0-beta.8.tgz",
-          "integrity": "sha512-KuOheWpI4MryCQmRP9NNI22IMd7TLZqakROYDrrzvBYGU/OfWrYA8ii3TjVPg2lFgxn95rC7cFrM69LIqOTDAg==",
+          "version": "21.3.0-beta.13",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-21.3.0-beta.13.tgz",
+          "integrity": "sha512-aoCg5uIuDuD6dEMXFzA17dM7DA+PbRRCnjdrko7JIqcrmk97aYSMYwYV2PhT013cBwYs9kM6tEaNvsHL7Y8KDg==",
           "dev": true,
           "requires": {
             "ansi-escapes": "3.0.0",
@@ -3344,18 +3534,19 @@
             "istanbul-lib-coverage": "1.1.1",
             "istanbul-lib-instrument": "1.9.1",
             "istanbul-lib-source-maps": "1.2.2",
-            "jest-changed-files": "21.2.0",
-            "jest-config": "21.3.0-beta.8",
-            "jest-environment-jsdom": "21.3.0-beta.8",
-            "jest-haste-map": "21.3.0-beta.8",
-            "jest-message-util": "21.3.0-beta.8",
+            "jest-changed-files": "21.3.0-beta.13",
+            "jest-config": "21.3.0-beta.13",
+            "jest-environment-jsdom": "21.3.0-beta.13",
+            "jest-get-type": "21.3.0-beta.13",
+            "jest-haste-map": "21.3.0-beta.13",
+            "jest-message-util": "21.3.0-beta.13",
             "jest-regex-util": "21.2.0",
             "jest-resolve-dependencies": "21.2.0",
-            "jest-runner": "21.3.0-beta.8",
-            "jest-runtime": "21.3.0-beta.8",
-            "jest-snapshot": "21.3.0-beta.8",
-            "jest-util": "21.3.0-beta.8",
-            "jest-worker": "21.3.0-beta.8",
+            "jest-runner": "21.3.0-beta.13",
+            "jest-runtime": "21.3.0-beta.13",
+            "jest-snapshot": "21.3.0-beta.13",
+            "jest-util": "21.3.0-beta.13",
+            "jest-worker": "21.3.0-beta.13",
             "micromatch": "2.3.11",
             "node-notifier": "5.1.2",
             "rimraf": "2.6.2",
@@ -3363,115 +3554,115 @@
             "string-length": "2.0.0",
             "strip-ansi": "4.0.0",
             "which": "1.3.0",
-            "yargs": "9.0.1"
+            "yargs": "10.0.3"
           }
         }
       }
     },
     "jest-changed-files": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-21.2.0.tgz",
-      "integrity": "sha512-+lCNP1IZLwN1NOIvBcV5zEL6GENK6TXrDj4UxWIeLvIsIDa+gf6J7hkqsW2qVVt/wvH65rVvcPwqXdps5eclTQ==",
+      "version": "21.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-21.3.0-beta.13.tgz",
+      "integrity": "sha512-0THUPXWdSfJkA7hskvOcoxorEapUdKs+IvK/7b9N5qfNTXUWz9YBaI+Yltj23my4Ua2w8mSsv7BBabF8oqgNGQ==",
       "dev": true,
       "requires": {
         "throat": "4.1.0"
       }
     },
     "jest-config": {
-      "version": "21.3.0-beta.8",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-21.3.0-beta.8.tgz",
-      "integrity": "sha512-OI8k6j2O7hOroqQjIrpmBdYM+cdvVF0lftmg0I6dvjve870YiDahPk4dHOZL3fxysT0qYE8Mzzmw4XJORRZsOA==",
+      "version": "21.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-21.3.0-beta.13.tgz",
+      "integrity": "sha512-5p+s5xrOzhz+daHQrZjjCuMiLtftRfEE5K986nBBvqxJssSzAUUUWYLt9GSi9+9uJYabGEt5ZgVVYjomCEeuvg==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
         "glob": "7.1.2",
-        "jest-environment-jsdom": "21.3.0-beta.8",
-        "jest-environment-node": "21.3.0-beta.8",
-        "jest-get-type": "21.3.0-beta.8",
-        "jest-jasmine2": "21.3.0-beta.8",
+        "jest-environment-jsdom": "21.3.0-beta.13",
+        "jest-environment-node": "21.3.0-beta.13",
+        "jest-get-type": "21.3.0-beta.13",
+        "jest-jasmine2": "21.3.0-beta.13",
         "jest-regex-util": "21.2.0",
-        "jest-resolve": "21.3.0-beta.8",
-        "jest-util": "21.3.0-beta.8",
-        "jest-validate": "21.3.0-beta.8",
-        "pretty-format": "21.3.0-beta.8"
+        "jest-resolve": "21.3.0-beta.13",
+        "jest-util": "21.3.0-beta.13",
+        "jest-validate": "21.3.0-beta.13",
+        "pretty-format": "21.3.0-beta.13"
       }
     },
     "jest-diff": {
-      "version": "21.3.0-beta.8",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.3.0-beta.8.tgz",
-      "integrity": "sha512-EbibyFyN0I/w/Tc0l0kjkGADKeP4c9VKJTIr2gHZvnxI99nMJyDfQtX6B6Q6NHLaUxVYBlU8OplYaq3EvkZqKQ==",
+      "version": "21.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.3.0-beta.13.tgz",
+      "integrity": "sha512-aFCjkJG7O6Vhc5sZDVhITMhCS/+bsGCdt6VFI77fcTYI9lZzBNYSmO1u5iIHga6StT2xkcpwCSfBR2/LUE0ADg==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
         "diff": "3.4.0",
-        "jest-get-type": "21.3.0-beta.8",
-        "pretty-format": "21.3.0-beta.8"
+        "jest-get-type": "21.3.0-beta.13",
+        "pretty-format": "21.3.0-beta.13"
       }
     },
     "jest-docblock": {
-      "version": "21.3.0-beta.8",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.3.0-beta.8.tgz",
-      "integrity": "sha512-qd63DpJjctWfOt9eM9OkwmZ8RiL7uFRM+5Tq31T/4E3q8Z+b7U1HCgNXX5WXYij91Dg47DAxx+lruAYGEMto1w==",
+      "version": "21.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.3.0-beta.13.tgz",
+      "integrity": "sha512-h8I4dCAkDvQcJG0q3bj0IO+1vXGm0jJtfTDXyA5H5DyUj59L9ADx3WZUYMG6PdutddAcUTfZJdRljWE5TaE95g==",
       "dev": true,
       "requires": {
         "detect-newline": "2.1.0"
       }
     },
     "jest-environment-jsdom": {
-      "version": "21.3.0-beta.8",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-21.3.0-beta.8.tgz",
-      "integrity": "sha512-fPIkg2i+XyDM8K6AEcvqKYndFIG1vGdjMRuhJ1wF4aTahIlo5IstSnZ9maEPI/B3TokVsMv28ytQ7tQ1TlLUXg==",
+      "version": "21.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-21.3.0-beta.13.tgz",
+      "integrity": "sha512-z9yRe29n3xa/kTp5woF3qYzGCkhvnQUWRuo/5o4Wx/AXqxUQ4IhGMHureGIs/Q+gt7iGotZRswdb01RCnSR4oQ==",
       "dev": true,
       "requires": {
-        "jest-mock": "21.3.0-beta.8",
-        "jest-util": "21.3.0-beta.8",
-        "jsdom": "11.2.0"
+        "jest-mock": "21.3.0-beta.13",
+        "jest-util": "21.3.0-beta.13",
+        "jsdom": "11.5.1"
       }
     },
     "jest-environment-node": {
-      "version": "21.3.0-beta.8",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-21.3.0-beta.8.tgz",
-      "integrity": "sha512-j8D01fKlrGCzB00NrUiZSatF2so9oJzqOrp6BTUBcp7ZDjxi0CbwrSohi9avZRQ2OWY0AchO3SUBHn3GniAn8A==",
+      "version": "21.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-21.3.0-beta.13.tgz",
+      "integrity": "sha512-en+7XKyNDHM3ZB5efi1Y5eUGL8ODwgdyJ9cCPHhOy9oWMRK0TQEmBbHWAUFbVg+gxPqRJHf7lQtTvkEKBOPvvQ==",
       "dev": true,
       "requires": {
-        "jest-mock": "21.3.0-beta.8",
-        "jest-util": "21.3.0-beta.8"
+        "jest-mock": "21.3.0-beta.13",
+        "jest-util": "21.3.0-beta.13"
       }
     },
     "jest-get-type": {
-      "version": "21.3.0-beta.8",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.3.0-beta.8.tgz",
-      "integrity": "sha512-zSwz9PwuItNhsrFFEkIv1tBvfSIXqFeRq6QQc/NaQe4XhTVmPqf1xJmNhe38piLz6prc0GsxY2iFNp+KASMk9w==",
+      "version": "21.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.3.0-beta.13.tgz",
+      "integrity": "sha512-2n5NUANtgqpKdN1crEl52OztxVobbUpM21gAIH8l6N9Ru33JhJ3cC8b/ln4CitbBZV5AyMzcAxSCDSo2ZmX0cA==",
       "dev": true
     },
     "jest-haste-map": {
-      "version": "21.3.0-beta.8",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-21.3.0-beta.8.tgz",
-      "integrity": "sha512-0yBxPGV91VRKg3IxQUMqw2/gD9vqKfJWuoP3om1yiX1WUT6WtvYVx5jECoMrJhY0FlsFTBR3WWtetFlpA+ebUg==",
+      "version": "21.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-21.3.0-beta.13.tgz",
+      "integrity": "sha512-WdLWIq7hzjy11U3UEF3DctxSpr3Q5Jb2an6ybvtZzCGUOXoPfhVBGkg2Tj2XhokkAwlaazUHKnITK1R5hDgXOg==",
       "dev": true,
       "requires": {
         "fb-watchman": "2.0.0",
         "graceful-fs": "4.1.11",
-        "jest-docblock": "21.3.0-beta.8",
-        "jest-worker": "21.3.0-beta.8",
+        "jest-docblock": "21.3.0-beta.13",
+        "jest-worker": "21.3.0-beta.13",
         "micromatch": "2.3.11",
         "sane": "2.2.0"
       }
     },
     "jest-jasmine2": {
-      "version": "21.3.0-beta.8",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-21.3.0-beta.8.tgz",
-      "integrity": "sha512-zTzIcGYB4FCe1F2mOtTUegkU4H0Vit0nVmKTtb158d/I1XS62QnkNyebWIoatfl3Da/ggEsBEJdnm/WBwTh9yQ==",
+      "version": "21.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-21.3.0-beta.13.tgz",
+      "integrity": "sha512-iydvs5DAs1Dc2oMFHaGX5gqgtbwNqOOganvLR2R+JkzvMnE6onB+v/1OvGP8Y7Z4F78kpBG9+6cIoITzen+RVQ==",
       "dev": true,
       "requires": {
         "callsites": "2.0.0",
         "chalk": "2.3.0",
-        "expect": "21.3.0-beta.8",
+        "expect": "21.3.0-beta.13",
         "graceful-fs": "4.1.11",
-        "jest-diff": "21.3.0-beta.8",
-        "jest-matcher-utils": "21.3.0-beta.8",
-        "jest-message-util": "21.3.0-beta.8",
-        "jest-snapshot": "21.3.0-beta.8",
+        "jest-diff": "21.3.0-beta.13",
+        "jest-matcher-utils": "21.3.0-beta.13",
+        "jest-message-util": "21.3.0-beta.13",
+        "jest-snapshot": "21.3.0-beta.13",
         "p-cancelable": "0.3.0",
         "source-map-support": "0.5.0"
       },
@@ -3493,21 +3684,31 @@
         }
       }
     },
+    "jest-leak-detector": {
+      "version": "21.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-21.3.0-beta.13.tgz",
+      "integrity": "sha512-XWss/NHswRuES8oTLuUybZxZF5sR0qCLVtbY9WOMyfo+xRHHDE5Z5MKlWjYJvpCi5aUIF2w0feMHcEdEJ0MlEg==",
+      "dev": true,
+      "requires": {
+        "pretty-format": "21.3.0-beta.13",
+        "weak": "1.0.1"
+      }
+    },
     "jest-matcher-utils": {
-      "version": "21.3.0-beta.8",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.3.0-beta.8.tgz",
-      "integrity": "sha512-Nq/zipbKDsLUcOqf/y9ZSeSQolRM+s4iej+pWpHQnNmDqhfo3ITEenFXsoNFAn0vSrdiuOZpH+zw/Aa2A5hKpQ==",
+      "version": "21.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.3.0-beta.13.tgz",
+      "integrity": "sha512-xflpRAFE+cmA6M9Q3WWtotu0wt2ya7xJforkxmqRStGpIZVmbFD+5dH1dodp13SR4w5LLhSW7y9giyGViEGNQw==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
-        "jest-get-type": "21.3.0-beta.8",
-        "pretty-format": "21.3.0-beta.8"
+        "jest-get-type": "21.3.0-beta.13",
+        "pretty-format": "21.3.0-beta.13"
       }
     },
     "jest-message-util": {
-      "version": "21.3.0-beta.8",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-21.3.0-beta.8.tgz",
-      "integrity": "sha512-ldQpJp/Z/anAwp2/Z0yzaHqBZI8j72bq35T1VcKejE94ijHw2RYxS1BQH7AbWQJhfnL9Mm6ecWUa4v8pY3fNhQ==",
+      "version": "21.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-21.3.0-beta.13.tgz",
+      "integrity": "sha512-UXTAM0oJswBAmETapplbinxXYDFzr4eqfQi9n3QZSCNkLFv0x+dqXCxaHAccRP+dQp6m9bR22DlxD8vSDsBizw==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
@@ -3517,9 +3718,9 @@
       }
     },
     "jest-mock": {
-      "version": "21.3.0-beta.8",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-21.3.0-beta.8.tgz",
-      "integrity": "sha512-yZkVavGpz+RKmUJ+4N0JxMyi8gxYv86zszclh7dDxSI5QJH637/rJN36roy01uZHwZyoguo69+39b5JAvOI+aw==",
+      "version": "21.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-21.3.0-beta.13.tgz",
+      "integrity": "sha512-V+osgTkpFbPDxoxcKw9CjvoF3+5GK+XCCo6HhvURK8R1gOSACpDJsHImXctdQr2u5W0YrjhH560y8Mfd405g7g==",
       "dev": true
     },
     "jest-regex-util": {
@@ -3529,9 +3730,9 @@
       "dev": true
     },
     "jest-resolve": {
-      "version": "21.3.0-beta.8",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-21.3.0-beta.8.tgz",
-      "integrity": "sha512-tAvd/aafNyvi7CswJR9/GJ6tWo9cv4vFl1VQK1kQY+7wNIStv0jWOAShKgRZ5Sb4Ow+vJ89SUcJVavfBPxaBKA==",
+      "version": "21.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-21.3.0-beta.13.tgz",
+      "integrity": "sha512-rQK0zHC70HlEcezF6YYKNDGQj82Go53elPnVhshwuEz6q1Zheo0ydfw/zv1brX04MLFVrNmBmwNS9adFhfzkRA==",
       "dev": true,
       "requires": {
         "browser-resolve": "1.11.2",
@@ -3548,44 +3749,46 @@
       }
     },
     "jest-runner": {
-      "version": "21.3.0-beta.8",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-21.3.0-beta.8.tgz",
-      "integrity": "sha512-1GFWklPXEgcFA3SSlV7dnnsAekcoIShkxtoneEAiv3z+rqXFvHASbpk+3ea7uaZhP9QmhpyzL7yWwuTbbgMaXQ==",
+      "version": "21.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-21.3.0-beta.13.tgz",
+      "integrity": "sha512-9JinOuuNKGMf7BwIvTj85kKj5Wl7jEmKVnA/7jmCWt9/aHWrMVKf6hmE8KM+/3UpgY59LmyU/kTub1uKRU5d6A==",
       "dev": true,
       "requires": {
-        "jest-config": "21.3.0-beta.8",
-        "jest-docblock": "21.3.0-beta.8",
-        "jest-haste-map": "21.3.0-beta.8",
-        "jest-jasmine2": "21.3.0-beta.8",
-        "jest-message-util": "21.3.0-beta.8",
-        "jest-runtime": "21.3.0-beta.8",
-        "jest-util": "21.3.0-beta.8",
-        "jest-worker": "21.3.0-beta.8",
+        "jest-config": "21.3.0-beta.13",
+        "jest-docblock": "21.3.0-beta.13",
+        "jest-haste-map": "21.3.0-beta.13",
+        "jest-jasmine2": "21.3.0-beta.13",
+        "jest-leak-detector": "21.3.0-beta.13",
+        "jest-message-util": "21.3.0-beta.13",
+        "jest-runtime": "21.3.0-beta.13",
+        "jest-util": "21.3.0-beta.13",
+        "jest-worker": "21.3.0-beta.13",
         "throat": "4.1.0"
       }
     },
     "jest-runtime": {
-      "version": "21.3.0-beta.8",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-21.3.0-beta.8.tgz",
-      "integrity": "sha512-pJT8sBmwyeFUzA2H48GfNiuSpiq9eA2wUeBYIbyFZqmvIMgDotxNMHUPWJ8OpCwHQVk6eN1Au8I4G6BLFLtjRw==",
+      "version": "21.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-21.3.0-beta.13.tgz",
+      "integrity": "sha512-1Wo0mNF9Ofz5B4gkhqzP72FgHMCy7k+AlEgJuyQ/85OwNJtipdUvd0lXzKdmjT0qy9B7bfCz6YCK3zTe9MQj1Q==",
       "dev": true,
       "requires": {
-        "babel-jest": "21.3.0-beta.8",
+        "babel-core": "6.26.0",
+        "babel-jest": "21.3.0-beta.13",
         "babel-plugin-istanbul": "4.1.5",
         "chalk": "2.3.0",
         "convert-source-map": "1.5.0",
         "graceful-fs": "4.1.11",
-        "jest-config": "21.3.0-beta.8",
-        "jest-haste-map": "21.3.0-beta.8",
+        "jest-config": "21.3.0-beta.13",
+        "jest-haste-map": "21.3.0-beta.13",
         "jest-regex-util": "21.2.0",
-        "jest-resolve": "21.3.0-beta.8",
-        "jest-util": "21.3.0-beta.8",
+        "jest-resolve": "21.3.0-beta.13",
+        "jest-util": "21.3.0-beta.13",
         "json-stable-stringify": "1.0.1",
         "micromatch": "2.3.11",
         "slash": "1.0.0",
         "strip-bom": "3.0.0",
         "write-file-atomic": "2.3.0",
-        "yargs": "9.0.1"
+        "yargs": "10.0.3"
       },
       "dependencies": {
         "strip-bom": {
@@ -3597,50 +3800,49 @@
       }
     },
     "jest-snapshot": {
-      "version": "21.3.0-beta.8",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-21.3.0-beta.8.tgz",
-      "integrity": "sha512-/oImZmrRhgVMfyMyVd8XeFH+0+jV8eoL07m9EmzckDYlPfSaOMqUpKVYAfPlEJYO/2XGe2DXUtQEiIXfrfDsHw==",
+      "version": "21.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-21.3.0-beta.13.tgz",
+      "integrity": "sha512-X32o1IZPj2iwKRYukChE1XEqS7qejgdNnEZw1Y6k2tijci5At4TVOAluSBo7ub6AcjfExJyKuOfdARa+SFsCZg==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
-        "jest-diff": "21.3.0-beta.8",
-        "jest-matcher-utils": "21.3.0-beta.8",
+        "jest-diff": "21.3.0-beta.13",
+        "jest-matcher-utils": "21.3.0-beta.13",
         "mkdirp": "0.5.1",
         "natural-compare": "1.4.0",
-        "pretty-format": "21.3.0-beta.8"
+        "pretty-format": "21.3.0-beta.13"
       }
     },
     "jest-util": {
-      "version": "21.3.0-beta.8",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-21.3.0-beta.8.tgz",
-      "integrity": "sha512-zHLRRw0BKBb1IxHduYl2MLCxMCASsnrhIe1wpEf3yK4HtTpYl/bYwVpMHbOuDNghnItKr5Iic/EtL9XVLCeIUA==",
+      "version": "21.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-21.3.0-beta.13.tgz",
+      "integrity": "sha512-mVUV/ckKYTOIZIKWB9uydCZWQ84+E9Xw3GWcaprgi9quGkzepIAJ8gRx3c4Zs94waU05OX80b8WaI2pOle7GCQ==",
       "dev": true,
       "requires": {
         "callsites": "2.0.0",
         "chalk": "2.3.0",
         "graceful-fs": "4.1.11",
-        "jest-message-util": "21.3.0-beta.8",
-        "jest-mock": "21.3.0-beta.8",
-        "jest-validate": "21.3.0-beta.8",
+        "jest-message-util": "21.3.0-beta.13",
+        "jest-validate": "21.3.0-beta.13",
         "mkdirp": "0.5.1"
       }
     },
     "jest-validate": {
-      "version": "21.3.0-beta.8",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.3.0-beta.8.tgz",
-      "integrity": "sha512-e/HNP6WWOOLNuBLBOT/IWq4fqASrMK0vEa4q88giKR7gsoI4jecF/aIhJJU8NOtGtxynz3XPS5bbDi5A2/m6pw==",
+      "version": "21.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.3.0-beta.13.tgz",
+      "integrity": "sha512-FHf6MgBuFcUVSymejj3DfQGN0J/Iuf6tMVyfhVHFRn3CbxXwifQ4Eqf1Bb8/v7IC6Uv/uYaK/aaEhwSvJBllQQ==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
-        "jest-get-type": "21.3.0-beta.8",
+        "jest-get-type": "21.3.0-beta.13",
         "leven": "2.1.0",
-        "pretty-format": "21.3.0-beta.8"
+        "pretty-format": "21.3.0-beta.13"
       }
     },
     "jest-worker": {
-      "version": "21.3.0-beta.8",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-21.3.0-beta.8.tgz",
-      "integrity": "sha512-GdKa7UhhTtjuBekLaWgYBh1ca0/Fpm3/7srKVUxbFwnDBVH01O+5DpLdstIfFrEHAjg7aXUopNNmm1zdYu+V3g==",
+      "version": "21.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-21.3.0-beta.13.tgz",
+      "integrity": "sha512-LjUuAkyE/VlhV3Yw9LWTpgP+Qen3t/3QEp95vQbd7rUaJ4wi7gtXpjCzCXUCVjtg+6c2yJh/mre3B2zbCA993Q==",
       "dev": true,
       "requires": {
         "merge-stream": "1.0.1"
@@ -3670,20 +3872,23 @@
       "optional": true
     },
     "jsdom": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.2.0.tgz",
-      "integrity": "sha512-+5wd6vJuh/Evw3wkmCuKXKibDd5RS7PYZjKaP4s2Hj5W7tvmbuFuaDN4erbH07VznTBFcK+lcsrGVnP6EugXow==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.5.1.tgz",
+      "integrity": "sha512-89ztIZ03aYK9f1uUrLXLsZndRge/JnZjzjpaN+lrse3coqz+8PR/dX4WLHpbF5fIKTXhDjFODOJw2328lPJ90g==",
       "dev": true,
       "requires": {
         "abab": "1.0.4",
-        "acorn": "4.0.13",
-        "acorn-globals": "3.1.0",
+        "acorn": "5.2.1",
+        "acorn-globals": "4.1.0",
         "array-equal": "1.0.0",
+        "browser-process-hrtime": "0.1.2",
         "content-type-parser": "1.0.2",
         "cssom": "0.3.2",
         "cssstyle": "0.2.37",
+        "domexception": "1.0.0",
         "escodegen": "1.9.0",
         "html-encoding-sniffer": "1.0.2",
+        "left-pad": "1.2.0",
         "nwmatcher": "1.4.3",
         "parse5": "3.0.3",
         "pn": "1.0.0",
@@ -3694,7 +3899,7 @@
         "tough-cookie": "2.3.3",
         "webidl-conversions": "4.0.2",
         "whatwg-encoding": "1.0.3",
-        "whatwg-url": "6.3.0",
+        "whatwg-url": "6.4.0",
         "xml-name-validator": "2.0.1"
       }
     },
@@ -3798,6 +4003,12 @@
         "invert-kv": "1.0.0"
       }
     },
+    "left-pad": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.2.0.tgz",
+      "integrity": "sha1-0wpzxrggHY99jnlWupYWCHpo4O4=",
+      "dev": true
+    },
     "leven": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
@@ -3825,14 +4036,6 @@
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
         "strip-bom": "2.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        }
       }
     },
     "locate-path": {
@@ -4469,14 +4672,6 @@
         "graceful-fs": "4.1.11",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        }
       }
     },
     "pause-stream": {
@@ -4572,9 +4767,9 @@
       }
     },
     "pretty-format": {
-      "version": "21.3.0-beta.8",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.3.0-beta.8.tgz",
-      "integrity": "sha512-2GJqwkxJtofmptZumdQHWlAduMBeEMpLy2NM6HvicgI9PtVHzgsObRuRfufMD709LB7UryI2F5xpIyziW+9vjg==",
+      "version": "21.3.0-beta.13",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.3.0-beta.13.tgz",
+      "integrity": "sha512-Yj7N6BYJkQQdVeKtQXN4ATHoMzyCFmr5par/QsujXjm1e49EzDzm4/7zYxrR4AvyuqrTVtfB+kljK82G0PHGOw==",
       "dev": true,
       "requires": {
         "ansi-regex": "3.0.0",
@@ -5685,6 +5880,17 @@
         }
       }
     },
+    "weak": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/weak/-/weak-1.0.1.tgz",
+      "integrity": "sha1-q5mqswcGlZqgIAy4z1RbucszuZ4=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "bindings": "1.3.0",
+        "nan": "2.8.0"
+      }
+    },
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -5707,9 +5913,9 @@
       "dev": true
     },
     "whatwg-url": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.3.0.tgz",
-      "integrity": "sha512-rM+hE5iYKGPAOu05mIdJR47pYSR2vDzfrTEFRc/S8D3L60yW8BuXmUJ7Kog7x/DrokFN7JNaHKadpzjouKRRAw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.0.tgz",
+      "integrity": "sha512-Z0CVh/YE217Foyb488eo+iBv+r7eAQ0wSTyApi9n06jhcA3z6Nidg/EGvl0UFkg7kMdKxfBzzr+o9JF+cevgMg==",
       "dev": true,
       "requires": {
         "lodash.sortby": "4.7.0",
@@ -5822,32 +6028,25 @@
       "dev": true
     },
     "yargs": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
-      "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
+      "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0",
         "cliui": "3.2.0",
         "decamelize": "1.2.0",
+        "find-up": "2.1.0",
         "get-caller-file": "1.0.2",
         "os-locale": "2.1.0",
-        "read-pkg-up": "2.0.0",
         "require-directory": "2.1.1",
         "require-main-filename": "1.0.1",
         "set-blocking": "2.0.0",
         "string-width": "2.1.1",
         "which-module": "2.0.0",
         "y18n": "3.2.1",
-        "yargs-parser": "7.0.0"
+        "yargs-parser": "8.0.0"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
         "cliui": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -5872,54 +6071,6 @@
             }
           }
         },
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
-          }
-        },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
-          "requires": {
-            "pify": "2.3.0"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
-          }
-        },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
@@ -5928,19 +6079,13 @@
           "requires": {
             "ansi-regex": "2.1.1"
           }
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
         }
       }
     },
     "yargs-parser": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-      "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
+      "integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
       "dev": true,
       "requires": {
         "camelcase": "4.1.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "prettier": "prettier --write '{src/**/,scripts/**/,}*.js'",
     "prettier:check": "prettier-check '{src/**/,scripts/**/,}*.js'",
     "test": "jest --no-cache --coverage",
-    "test:ci": "run-p test prettier:check lint"
+    "test:ci": "run-p test prettier:check lint",
+    "test:debug": "node --inspect-brk node_modules/.bin/jest -i"
   },
   "dependencies": {},
   "peerDependencies": {
@@ -31,6 +32,8 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
+    "babel-eslint": "^8.0.3",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",
@@ -38,7 +41,7 @@
     "enzyme-adapter-react-16": "^1.1.0",
     "eslint": "^4.12.1",
     "eslint-plugin-jsx-a11y": "^6.0.2",
-    "jest": "^21.3.0-beta.8",
+    "jest": "^21.3.0-beta.13",
     "npm-run-all": "^4.1.2",
     "prettier": "^1.8.2",
     "prettier-check": "^2.0.0",

--- a/src/Router/RenderComponentForRoute.js
+++ b/src/Router/RenderComponentForRoute.js
@@ -1,0 +1,57 @@
+import { createElement, Component } from 'react';
+import { shape, func, string, object } from 'prop-types';
+
+export default class RenderComponentForRoute extends Component {
+    static propTypes = {
+        route: shape({
+            urlPattern: string.isRequired,
+            getComponent: func.isRequired
+        }).isRequired,
+        /* () => React.Element<any> */
+        renderLoading: func,
+        /* (err: Error) => React.Element<any> */
+        renderRouteError: func.isRequired,
+        routeProps: shape({
+            match: object.isRequired,
+            location: object.isRequired,
+            history: object.isRequired
+        }).isRequired
+    };
+
+    state = {
+        RouteComponent: null,
+        routingError: null
+    };
+
+    unwrapAndCacheRouteComponent() {
+        const { route } = this.props;
+        // `getComponent` can synchronously return a component, or a promise
+        // that will resolve to a component.
+        Promise.resolve(route.getComponent())
+            .then(RouteComponent => {
+                this.setState({ RouteComponent });
+            })
+            .catch(err => {
+                this.setState({ routingError: err });
+            });
+    }
+
+    componentDidMount() {
+        this.unwrapAndCacheRouteComponent();
+    }
+
+    render() {
+        const { renderLoading, renderRouteError, routeProps } = this.props;
+        const { RouteComponent, routingError } = this.state;
+
+        if (routingError) {
+            return renderRouteError(routingError);
+        }
+
+        if (!RouteComponent) {
+            return renderLoading ? renderLoading() : null;
+        }
+
+        return <RouteComponent {...routeProps} />;
+    }
+}

--- a/src/Router/Router.js
+++ b/src/Router/Router.js
@@ -1,0 +1,92 @@
+import { createElement, Component } from 'react';
+import { BrowserRouter, Route, Switch } from 'react-router-dom';
+import { arrayOf, shape, string, func, object } from 'prop-types';
+import UnknownRouteResolver from './UnknownRouteResolver';
+import RenderComponentForRoute from './RenderComponentForRoute';
+
+export default class MagentoRouter extends Component {
+    static propTypes = {
+        // Note: Initial list of standard routes will likely be
+        // hardcoded into this lib. Just accepting a prop for now
+        routes: arrayOf(
+            shape({
+                urlPattern: string.isRequired,
+                getComponent: func.isRequired
+            })
+        ),
+        /* () => React.Element<any> */
+        render404: func.isRequired,
+        /* (err: Error) => React.Element<any> */
+        renderRouteError: func.isRequired,
+        /* (route: string) => Promise<string> */
+        resolveUnknownRoute: func.isRequired,
+        /* () => React.Element<any> */
+        renderLoading: func,
+        /* Can be BrowserRouter, MemoryRouter, HashRouter, etc */
+        Router: func,
+        routerProps: object
+    };
+
+    static defaultProps = {
+        Router: BrowserRouter,
+        routerProps: {}
+    };
+
+    state = {
+        lazyRoutes: []
+    };
+
+    registerRoute = route => {
+        this.setState(prevState => ({
+            lazyRoutes: [...prevState.lazyRoutes, route]
+        }));
+    };
+
+    render() {
+        const {
+            routes,
+            render404,
+            renderRouteError,
+            resolveUnknownRoute,
+            renderLoading,
+            Router,
+            routerProps
+        } = this.props;
+        const { lazyRoutes } = this.state;
+
+        return (
+            <Router {...routerProps}>
+                <Switch>
+                    {routes
+                        .concat(lazyRoutes)
+                        .map(route => (
+                            <Route
+                                key={route.urlPattern}
+                                path={route.urlPattern}
+                                render={routeProps => (
+                                    <RenderComponentForRoute
+                                        routeProps={routeProps}
+                                        route={route}
+                                        renderLoading={renderLoading}
+                                        renderRouteError={renderRouteError}
+                                    />
+                                )}
+                            />
+                        ))}
+                    <Route
+                        render={({ location = {} }) => (
+                            <UnknownRouteResolver
+                                routes={routes}
+                                pathname={location.pathname || ''}
+                                resolveUnknownRoute={resolveUnknownRoute}
+                                registerRoute={this.registerRoute}
+                                render404={render404}
+                                renderRouteError={renderRouteError}
+                            />
+                        )}
+                    />
+                </Switch>
+            </Router>
+        );
+    }
+}

--- a/src/Router/UnknownRouteResolver.js
+++ b/src/Router/UnknownRouteResolver.js
@@ -1,0 +1,64 @@
+import { createElement, Component } from 'react';
+import { func, arrayOf, shape, string } from 'prop-types';
+import { matchPath } from 'react-router';
+
+export default class UnknownRouteResolver extends Component {
+    static propTypes = {
+        routes: arrayOf(
+            shape({
+                urlPattern: string.isRequired,
+                getComponent: func.isRequired
+            })
+        ).isRequired,
+        pathname: string.isRequired,
+        /* (route: string) => string */
+        resolveUnknownRoute: func.isRequired,
+        /* (route: object) => void */
+        registerRoute: func.isRequired,
+        /* () => React.Element<any> */
+        render404: func.isRequired,
+        /* (err: Error) => React.Element<any> */
+        renderRouteError: func.isRequired
+    };
+
+    componentDidMount() {
+        this.handleRoute(this.props.pathname);
+    }
+
+    handleRoute(url) {
+        const {
+            resolveUnknownRoute,
+            renderRouteError,
+            routes,
+            registerRoute,
+            render404
+        } = this.props;
+        resolveUnknownRoute(url)
+            .then(stdRoute => {
+                // Find route definition matching the standard route,
+                // so we can determine what root component to render
+                const route = routes.find(route => {
+                    return matchPath(stdRoute, {
+                        path: route.urlPattern,
+                        strict: true,
+                        exact: true
+                    });
+                });
+
+                registerRoute({
+                    getComponent: route ? route.getComponent : () => render404,
+                    urlPattern: url
+                });
+            })
+            .catch(err => {
+                registerRoute({
+                    getComponent: () => () => renderRouteError(err),
+                    urlPattern: url
+                });
+            });
+    }
+
+    render() {
+        return null;
+    }
+}

--- a/src/Router/__tests__/Router.test.js
+++ b/src/Router/__tests__/Router.test.js
@@ -1,0 +1,215 @@
+import Router from '..';
+import { createElement } from 'react';
+import { configure, shallow, mount } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import { MemoryRouter } from 'react-router-dom';
+import UnknownRouteResolver from '../UnknownRouteResolver';
+
+configure({ adapter: new Adapter() });
+
+const routes = [
+    {
+        urlPattern: '/catalog/product/view/id/:id',
+        getComponent: () => () => <div>Foo Bar</div>
+    }
+];
+const render404 = () => <div>404</div>;
+const renderLoading = () => <div>Loading</div>;
+const renderRouteError = () => <div>Error</div>;
+const noop = () => {};
+const defaultTestProps = {
+    Router: MemoryRouter,
+    routes,
+    renderLoading,
+    render404,
+    renderRouteError,
+    resolveUnknownRoute: noop
+};
+
+test('Renders a `Route` component for a supplied route', () => {
+    const wrapper = shallow(<Router {...defaultTestProps} />);
+    const route = wrapper.find('Route[path="/catalog/product/view/id/:id"]');
+    expect(route.length).toBe(1);
+});
+
+test('Renders the UnknownRouteResolver as the last route, with no path', () => {
+    const wrapper = shallow(<Router {...defaultTestProps} />);
+    const lastRoute = wrapper.find('Route').last();
+    expect(lastRoute.props().path).toBeUndefined();
+    const renderedTree = lastRoute.props().render({});
+    expect(renderedTree.type).toBe(UnknownRouteResolver);
+});
+
+test('Navigating to a known route renders its associated component', cb => {
+    const wrapper = mount(
+        <Router
+            {...defaultTestProps}
+            routerProps={{
+                initialEntries: ['/catalog/product/view/id/1'],
+                initialIndex: 0
+            }}
+        />
+    );
+    process.nextTick(() => {
+        expect(wrapper.render().toString()).toEqual('<div>Foo Bar</div>');
+        cb();
+    });
+});
+
+test('Result of renderLoading() rendered during route transition', () => {
+    const wrapper = shallow(
+        <Router
+            {...defaultTestProps}
+            routerProps={{
+                initialEntries: ['/catalog/product/view/id/1'],
+                initialIndex: 0
+            }}
+        />
+    );
+    expect(wrapper.render().toString()).toEqual('<div>Loading</div>');
+});
+
+test('Unknown routes can be lazily registered through "resolveUnknownRoute" fn prop', cb => {
+    const resolveUnknownRoute = jest.fn(() =>
+        Promise.resolve('/catalog/product/view/id/1')
+    );
+    const wrapper = mount(
+        <Router
+            {...defaultTestProps}
+            routerProps={{
+                initialEntries: ['/my-cool-product.html'],
+                initialIndex: 0
+            }}
+            resolveUnknownRoute={resolveUnknownRoute}
+        />
+    );
+    expect(resolveUnknownRoute).toHaveBeenCalledWith('/my-cool-product.html');
+    process.nextTick(() => {
+        expect(wrapper.render().toString()).toEqual('<div>Foo Bar</div>');
+        cb();
+    });
+});
+
+test('Unknown routes not found with "resolveUnknownRoute" render 404', cb => {
+    // Current test case assumes that the GraphQLAPI we get will to use in `resolveUnknownRoute`
+    // will return an empty string when it can't find a match. This will likely change,
+    // and so will this code
+    const resolveUnknownRoute = () => Promise.resolve('');
+    const wrapper = mount(
+        <Router
+            {...defaultTestProps}
+            routerProps={{
+                initialEntries: ['/mystery-path.html'],
+                initialIndex: 0
+            }}
+            resolveUnknownRoute={resolveUnknownRoute}
+        />
+    );
+    process.nextTick(() => {
+        expect(wrapper.render().toString()).toEqual('<div>404</div>');
+        cb();
+    });
+});
+
+test('Unknown routes that cause "resolveUnknownRoute" to reject render the error page', cb => {
+    const resolveUnknownRoute = () => Promise.reject(new Error('some error'));
+    const wrapper = mount(
+        <Router
+            {...defaultTestProps}
+            routerProps={{
+                initialEntries: ['/mystery-path.html'],
+                initialIndex: 0
+            }}
+            resolveUnknownRoute={resolveUnknownRoute}
+        />
+    );
+    process.nextTick(() => {
+        expect(wrapper.render().toString()).toEqual('<div>Error</div>');
+        cb();
+    });
+});
+
+test('"getComponent" on a route def can return a component synchronously', cb => {
+    const routes = [
+        {
+            urlPattern: '/my-cool-product.html',
+            getComponent: () => () => <div>Foo Bar</div>
+        }
+    ];
+    const wrapper = mount(
+        <Router
+            {...defaultTestProps}
+            routerProps={{
+                initialEntries: ['/my-cool-product.html'],
+                initialIndex: 0
+            }}
+            routes={routes}
+        />
+    );
+    process.nextTick(() => {
+        expect(wrapper.render().toString()).toEqual('<div>Foo Bar</div>');
+        cb();
+    });
+});
+
+test('"getComponent" on a route def can return a promise resolving to a comp', cb => {
+    const routes = [
+        {
+            urlPattern: '/my-cool-product.html',
+            getComponent: () => Promise.resolve(() => <div>Foo Bar</div>)
+        }
+    ];
+    const wrapper = mount(
+        <Router
+            {...defaultTestProps}
+            routerProps={{
+                initialEntries: ['/my-cool-product.html'],
+                initialIndex: 0
+            }}
+            routes={routes}
+        />
+    );
+    process.nextTick(() => {
+        expect(wrapper.render().toString()).toEqual('<div>Foo Bar</div>');
+        cb();
+    });
+});
+
+test('Renders result of "renderRouteError" when the fetching of a Component rejects', cb => {
+    const routes = [
+        {
+            urlPattern: '/my-cool-product.html',
+            getComponent: () => Promise.reject(new Error('some error'))
+        }
+    ];
+    const wrapper = mount(
+        <Router
+            {...defaultTestProps}
+            routerProps={{
+                initialEntries: ['/my-cool-product.html'],
+                initialIndex: 0
+            }}
+            routes={routes}
+        />
+    );
+    process.nextTick(() => {
+        expect(wrapper.render().toString()).toEqual('<div>Error</div>');
+        cb();
+    });
+});
+
+test('Renders result of "renderRouteError" when "resolveUnknownRoute" rejects', cb => {
+    const resolveUnknownRoute = jest.fn(() =>
+        Promise.reject(new Error('some error'))
+    );
+    const wrapper = mount(
+        <Router
+            {...defaultTestProps}
+            resolveUnknownRoute={resolveUnknownRoute}
+        />
+    );
+    process.nextTick(() => {
+        expect(wrapper.render().toString()).toEqual('<div>Error</div>');
+        cb();
+    });
+});

--- a/src/Router/index.js
+++ b/src/Router/index.js
@@ -1,0 +1,1 @@
+export { default } from './Router';


### PR DESCRIPTION
Haven't wired it into the main library export yet (the "connector"), but unit tests are present. Please call out if I'm not testing any scenarios that you recognize.

This is primarily based off the [HLD](https://wiki.corp.magento.com/pages/viewpage.action?spaceKey=MAGE2&title=HLD+-+Support+Routing+with+existing+Magento+routes+in+PWA) that Dan Mooney and I worked on.

There will be a wrapped `<Link />` component later on that will allow us to skip the round trip to validate a route (in certain scenarios), but that's outside the scope of this PR.

Screenshot below is the setup I've been using in `pwa-module-theme/theme` to validate this. In a real usage, `resolveUnknownRoute` would be from an API module or something we've created, and the stubbed routes would be some generated artifact from the build that associates page components to a route def (next story). The `Promise.resolve` in `getComponent` would also be a fn using `import()` to lazily fetch the component def.

![screenshot](https://user-images.githubusercontent.com/5233399/33920169-1f76b082-df82-11e7-981b-c7cd9a2af6fb.png).
