### PR TITLE
Add coverage doc in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 .DS_Store
 dist
+coverage

--- a/circle.yml
+++ b/circle.yml
@@ -5,3 +5,7 @@ machine:
 test:
   override:
     - npm run test:ci
+
+general:
+  artifacts:
+    - "coverage/lcov-report"

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    rootDir: 'src',
-    setupFiles: ['../scripts/shim.js'],
-    verbose: true
+    setupFiles: ['<rootDir>/scripts/shim.js'],
+    verbose: true,
+    collectCoverageFrom: ['src/**/*.js']
 };

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint": "eslint 'src/**/*.js'",
     "prettier": "prettier --write '{src/**/,scripts/**/,}*.js'",
     "prettier:check": "prettier-check '{src/**/,scripts/**/,}*.js'",
-    "test": "jest --no-cache",
+    "test": "jest --no-cache --coverage",
     "test:ci": "run-p test prettier:check lint"
   },
   "dependencies": {},


### PR DESCRIPTION
We can discuss using a service like `CodeClimate` at some point. But for now, this at least allows us to view coverage in a PR without having to pull it down and run it locally.

[Example report](https://20-109054692-gh.circle-artifacts.com/0/home/ubuntu/peregrine/coverage/lcov-report/index.html)