### PR TITLE
Stub console.log out in Peregrine root test to keep stdout clean

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
     setupFiles: ['<rootDir>/scripts/shim.js'],
     verbose: true,
-    collectCoverageFrom: ['src/**/*.js']
+    collectCoverageFrom: ['src/**/*.js'],
+    silent: !process.env.DEBUG
 };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prettier:check": "prettier-check '{src/**/,scripts/**/,}*.js'",
     "test": "jest --no-cache --coverage",
     "test:ci": "run-p test prettier:check lint",
-    "test:debug": "node --inspect-brk node_modules/.bin/jest -i"
+    "test:debug": "DEBUG=1 node --inspect-brk node_modules/.bin/jest -i"
   },
   "dependencies": {},
   "peerDependencies": {


### PR DESCRIPTION
Running tests on `master`:
![image](https://user-images.githubusercontent.com/5233399/34423441-9db992dc-ebe1-11e7-9ce9-374534630619.png)

![image](https://user-images.githubusercontent.com/5233399/34423449-acd97d9a-ebe1-11e7-8973-bd283eb908da.png)
