### PR TITLE
Switch to async/await based on prior decision

### DIFF
--- a/src/Router/RenderComponentForRoute.js
+++ b/src/Router/RenderComponentForRoute.js
@@ -23,17 +23,14 @@ export default class RenderComponentForRoute extends Component {
         routingError: null
     };
 
-    unwrapAndCacheRouteComponent() {
+    async unwrapAndCacheRouteComponent() {
         const { route } = this.props;
-        // `getComponent` can synchronously return a component, or a promise
-        // that will resolve to a component.
-        Promise.resolve(route.getComponent())
-            .then(RouteComponent => {
-                this.setState({ RouteComponent });
-            })
-            .catch(err => {
-                this.setState({ routingError: err });
-            });
+        try {
+            const RouteComponent = await route.getComponent();
+            this.setState({ RouteComponent });
+        } catch (err) {
+            this.setState({ routingError: err });
+        }
     }
 
     componentDidMount() {

--- a/src/Router/UnknownRouteResolver.js
+++ b/src/Router/UnknownRouteResolver.js
@@ -25,7 +25,7 @@ export default class UnknownRouteResolver extends Component {
         this.handleRoute(this.props.pathname);
     }
 
-    handleRoute(url) {
+    async handleRoute(url) {
         const {
             resolveUnknownRoute,
             renderRouteError,
@@ -33,29 +33,29 @@ export default class UnknownRouteResolver extends Component {
             registerRoute,
             render404
         } = this.props;
-        resolveUnknownRoute(url)
-            .then(stdRoute => {
-                // Find route definition matching the standard route,
-                // so we can determine what root component to render
-                const route = routes.find(route => {
-                    return matchPath(stdRoute, {
-                        path: route.urlPattern,
-                        strict: true,
-                        exact: true
-                    });
-                });
 
-                registerRoute({
-                    getComponent: route ? route.getComponent : () => render404,
-                    urlPattern: url
-                });
-            })
-            .catch(err => {
-                registerRoute({
-                    getComponent: () => () => renderRouteError(err),
-                    urlPattern: url
+        try {
+            const stdRoute = await resolveUnknownRoute(url);
+            // Find route definition matching the standard route,
+            // so we can determine what root component to render
+            const route = routes.find(route => {
+                return matchPath(stdRoute, {
+                    path: route.urlPattern,
+                    strict: true,
+                    exact: true
                 });
             });
+
+            registerRoute({
+                getComponent: route ? route.getComponent : () => render404,
+                urlPattern: url
+            });
+        } catch (err) {
+            registerRoute({
+                getComponent: () => () => renderRouteError(err),
+                urlPattern: url
+            });
+        }
     }
 
     render() {


### PR DESCRIPTION
Decision was made to adopt `async`/`await` syntax in this lib, so I've updated Router code to keep consistent.