### PR TITLE
Publish to npm upon versioned tag push to Github

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,3 +9,13 @@ test:
 general:
   artifacts:
     - "coverage/lcov-report"
+
+dependencies:
+  pre:
+    - echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+
+deployment:
+  npm:
+    tag: /v[0-9]+(\.[0-9]+)*/
+    commands:
+      - npm publish

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
-  "name": "peregrine",
-  "private": true,
-  "version": "0.1.0",
+  "name": "@magento/peregrine",
+  "version": "0.1.0-alpha",
   "description": "The core runtime of Magento PWA",
   "license": "(OSL-3.0 OR AFL-3.0)",
   "author": "Magento Commerce",
   "main": "dist/index.js",
-  "module": "dist/index.js",
+  "files": [
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/magento-research/peregrine"


### PR DESCRIPTION
True test of this will be after I merge + push a tag.

After this is setup, we can just `npm i @magento/peregrine` in `pwa-module-theme`