### PR TITLE
Explicitly set NODE_ENV to production when running build in CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,5 +18,5 @@ deployment:
   npm:
     tag: /v[0-9]+(\.[0-9]+)*(-(alpha|beta))?/
     commands:
-      - npm run build
+      - NODE_ENV=production npm run build
       - npm publish --access=public


### PR DESCRIPTION
Closes #18 