### PR TITLE
Don't quiet the console everywhere

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,5 @@
 module.exports = {
     setupFiles: ['<rootDir>/scripts/shim.js'],
     verbose: true,
-    collectCoverageFrom: ['src/**/*.js'],
-    silent: !process.env.DEBUG
+    collectCoverageFrom: ['src/**/*.js']
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prettier:check": "prettier-check '{src/**/,scripts/**/,}*.js'",
     "test": "jest --no-cache --coverage",
     "test:ci": "run-p test prettier:check lint",
-    "test:debug": "DEBUG=1 node --inspect-brk node_modules/.bin/jest -i"
+    "test:debug": "node --inspect-brk node_modules/.bin/jest -i"
   },
   "dependencies": {},
   "peerDependencies": {

--- a/src/Peregrine/__tests__/Peregrine.test.js
+++ b/src/Peregrine/__tests__/Peregrine.test.js
@@ -8,6 +8,18 @@ configure({ adapter: new Adapter() });
 
 const SimpleComponent = () => <i />;
 
+beforeAll(() => {
+    for (const method of Object.keys(console)) {
+        jest.spyOn(console, method).mockImplementation(() => {});
+    }
+});
+
+afterAll(() => {
+    for (const method of Object.values(console)) {
+        method.mockRestore();
+    }
+});
+
 test('Constructs a new Peregrine instance', () => {
     const received = new Peregrine(SimpleComponent);
 


### PR DESCRIPTION
In #11, my original implementation only made the console quiet in `Peregrine.test.js`. There was a [request to do this globally for _all_ tests](https://github.com/magento-research/peregrine/pull/11#pullrequestreview-86181060).

This has bit me multiple times now, when I'm debugging and want to `console.log` a value, and have to remember why it's not working. I could open up the full debugger everytime, but frequently it's more convenient to just spit something to `stdout`.

I've moved the implementation back to only quiet the console in `Peregrine.test.js`, since the large majority of tests/functionality are never going to spit content to the console