### PR TITLE
Ensure __tmp_webpack_public_path__ always has a trailing slash

### DIFF
--- a/src/Peregrine/Peregrine.js
+++ b/src/Peregrine/Peregrine.js
@@ -22,12 +22,14 @@ class Peregrine {
     constructor(opts = {}) {
         const { apiBase = location.origin, __tmp_webpack_public_path__ } = opts;
         this.apiBase = apiBase;
-        this.__tmp_webpack_public_path__ = __tmp_webpack_public_path__;
+        this.__tmp_webpack_public_path__ =
+            __tmp_webpack_public_path__ &&
+            ensureDirURI(__tmp_webpack_public_path__);
         if (!__tmp_webpack_public_path__ && process.env.NODE_ENV === 'test') {
             // Since __tmp_webpack_public_path__ is temporary, we're
             // defaulting it here in tests to lessen tests that need to change
             // when this property is removed
-            this.__tmp_webpack_public_path__ = 'https://temporary.com/pub';
+            this.__tmp_webpack_public_path__ = 'https://temporary.com/pub/';
         }
         this.store = createStore();
         this.container = null;
@@ -75,6 +77,14 @@ class Peregrine {
     addReducer(key, reducer) {
         this.store.addReducer(key, reducer);
     }
+}
+
+/**
+ * Given a URI, will always return the same URI with a trailing slash
+ * @param {string} uri
+ */
+function ensureDirURI(uri) {
+    return uri.endsWith('/') ? uri : uri + '/';
 }
 
 export default Peregrine;

--- a/src/Peregrine/__tests__/Peregrine.test.js
+++ b/src/Peregrine/__tests__/Peregrine.test.js
@@ -62,3 +62,18 @@ test('Adds a reducer to the store', () => {
     const next = app.store.getState().foo;
     expect(next).toBe(expected);
 });
+
+// https://github.com/magento-research/venia-pwa-concept/pull/57
+test('__tmp_webpack_public_path__ is normalized to include a trailing / when not present', () => {
+    const app = new Peregrine({
+        __tmp_webpack_public_path__: 'https://foo.bar/test'
+    });
+    expect(app.__tmp_webpack_public_path__).toBe('https://foo.bar/test/');
+});
+
+test('Does not double up trailing slash in __tmp_webpack_public_path__ when one exists', () => {
+    const app = new Peregrine({
+        __tmp_webpack_public_path__: 'https://foo.bar/test/'
+    });
+    expect(app.__tmp_webpack_public_path__).toBe('https://foo.bar/test/');
+});


### PR DESCRIPTION
See: https://github.com/magento-research/venia-pwa-concept/pull/57

Reminder that `__tmp_webpack_public_path__` goes away entirely once the backend work to support root components is done.