### PR TITLE
(Breaking Change) Change Peregrine's bootstrapping API

### DIFF
--- a/src/Peregrine/Peregrine.js
+++ b/src/Peregrine/Peregrine.js
@@ -1,82 +1,36 @@
 import { createElement } from 'react';
-import { Provider } from 'react-redux';
-import { render } from 'react-dom';
+import { Provider as ReduxProvider } from 'react-redux';
 import createStore from '../store';
 import MagentoRouter from '../Router';
 
 /**
- * @class
- * @prop {Element} container
- * @prop {ReactElement} element
- * @prop {Store} store
- * @prop {string} apiBase
- * @prop {string} __tmp_webpack_public_path__
+ *
+ * @param {string} apiBase Absolute URL pointing to the GraphQL endpoint
+ * @param {string} __tmp_webpack_public_path__ Temporary hack. Expects the `__webpack_public_path__` value
+ * @returns {{ store: Store, Provider: () => JSX.Element }}
  */
-class Peregrine {
-    /**
-     * Create a Peregrine instance.
-     * @param {object} opts
-     * @param {string} opts.apiBase Base URL for the store's GraphQL API, including host/port
-     * @param {string} opts.__tmp_webpack_public_path__ Temporary until PWA module extends GraphQL API
-     */
-    constructor(opts = {}) {
-        const { apiBase = location.origin, __tmp_webpack_public_path__ } = opts;
-        this.apiBase = apiBase;
-        this.__tmp_webpack_public_path__ =
-            __tmp_webpack_public_path__ &&
-            ensureDirURI(__tmp_webpack_public_path__);
-        if (!__tmp_webpack_public_path__ && process.env.NODE_ENV === 'test') {
-            // Since __tmp_webpack_public_path__ is temporary, we're
-            // defaulting it here in tests to lessen tests that need to change
-            // when this property is removed
-            this.__tmp_webpack_public_path__ = 'https://temporary.com/pub/';
-        }
-        this.store = createStore();
-        this.container = null;
-        this.element = null;
-    }
-
-    /**
-     * Create an instance of the root component, wrapped with store and routing
-     * components.
-     *
-     * @returns {ReactElement}
-     */
-    render() {
-        const { store, apiBase, __tmp_webpack_public_path__ } = this;
-
-        return (
-            <Provider store={store}>
-                <MagentoRouter {...{ apiBase, __tmp_webpack_public_path__ }} />
-            </Provider>
+export default function bootstrap({ apiBase, __tmp_webpack_public_path__ }) {
+    // Remove deprecation warning after 2 version bumps
+    if (process.env.NODE_ENV !== 'production' && this instanceof bootstrap) {
+        throw new Error(
+            'The API for Peregrine has changed. ' +
+                'Please see the Release Notes on Github ' +
+                'for instructions to update your application'
         );
     }
 
-    /**
-     * Render and mount the React tree into a DOM element.
-     *
-     * @param {Element} container The target DOM element.
-     * @param {Function} callback A function called after mounting.
-     * @returns {void}
-     */
-    mount(container) {
-        this.container = container;
-        this.element = this.render();
+    const store = createStore();
+    const routerProps = {
+        apiBase,
+        __tmp_webpack_public_path__: ensureDirURI(__tmp_webpack_public_path__)
+    };
+    const Provider = () => (
+        <ReduxProvider store={store}>
+            <MagentoRouter {...routerProps} />
+        </ReduxProvider>
+    );
 
-        render(this.element, ...arguments);
-    }
-
-    /**
-     * Add a reducer (slice) to the store (root).
-     * The store replaces the root reducer with one containing the new slice.
-     *
-     * @param {String} key The name of the slice.
-     * @param {Function} reducer The reducing function.
-     * @returns {void}
-     */
-    addReducer(key, reducer) {
-        this.store.addReducer(key, reducer);
-    }
+    return { store, Provider };
 }
 
 /**
@@ -86,5 +40,3 @@ class Peregrine {
 function ensureDirURI(uri) {
     return uri.endsWith('/') ? uri : uri + '/';
 }
-
-export default Peregrine;


### PR DESCRIPTION
<!-- (REQUIRED) What is the nature of this PR? -->
## This PR is a:
[ ] New feature
[ ] Enhancement/Optimization
[X] Refactor
[ ] Bugfix
[ ] Test for existing code
[ ] Documentation

<!-- (REQUIRED) What does this PR change? -->
## Summary
 
This PR changes the public API for bootstrapping a Peregrine application. Currently, `Peregrine` abstracts away the call to `ReactDOM.render`, and only accepts the DOM element that should host the application.

This is not ideal, because it makes it more difficult to wrap additional context providers in the root of the component tree.

This PR inverts things. The current API accepts all the data it needs, and then takes care of rendering on your behalf. The new API in this PR accepts all the data it needs, but returns to the consumer everything that would need to be used with `ReactDOM.render`. This is similar to switching from an HOC to a render prop - we're returning control back to the user of the component.

**Current Theme Code**
```js
const app = new Peregrine({
    apiBase: new URL('/graphql', location.origin).toString(),
    __tmp_webpack_public_path__: __webpack_public_path__
});

app.mount(document.getElementById('root'));
```

**New Theme Code**
```js
const { Provider } = bootstrap({
    apiBase: new URL('/graphql', location.origin).toString(),
    __tmp_webpack_public_path__: __webpack_public_path__
});

ReactDOM.render(<Provider />, document.getElementById('root'));
```

Note that the API where you call a function and it returns an object with a `Provider` is very similar to the `React.createContext` API in React 16. This is intentional.

Now, if a consumer wants to wrap additional providers at the root of the component tree, they can just do:

```js
ReactDOM.render(
   <SomeOtherProvider>
	 <PeregrineProvider />
   </SomeOtherProvider>,
   document.getElementById('root')
);
```
 
<!-- (OPTIONAL) What other information can you provide about this PR? -->
## Additional information

<!--
Thank you for your contribution!
 
Before submitting this pull request, please make sure you have read our Contribution Guidelines and your PR meets our contribution standards:
https://github.com/magento-research/peregrine/blob/develop/.github/CONTRIBUTION.md
 
Please fill out as much information as you can about your PR to help speed up the review process.
If your PR addresses an existing GitHub Issue, please refer to it in the title or Additional Information section to make the connection.
 
We may ask you for changes in your PR in order to meet the standards set in our Contribution Guidelines. PR's that do not comply with our guidelines may be closed at the maintainers' discretion.

Feel free to remove this section before creating this PR.
-->